### PR TITLE
Add spellpower trinket/proc tracking

### DIFF
--- a/EventHorizon/EventHorizon.lua
+++ b/EventHorizon/EventHorizon.lua
@@ -713,9 +713,17 @@ function EventHorizon:Initialize()
 			refreshable = true,
 		})
 		
+		if UnitRace("player") == "Undead" then
+			self:NewSpell(19280, 'dp', {
+				debuff = 24,
+				dot = 3,
+				cooldown = 180,
+			})
+		end
+		
 		 self:NewSpell(8092, 'mb', {
-		 	cast = 1.5,
-		 	cooldown = 6,
+			cast = 1.5,
+			cooldown = 6,
 		 })
 		 
 		self:NewSpell(32379, 'swd', {


### PR DESCRIPTION
To help snapshotting, add a 'buff' spell type that shows procs in the timeline.

Also rearranged spells to personal taste (selfish, I know) and removed DP because I'm a pepega dwarf.

Added a translucent background to make things easier to see.

No idea how nicely these changes have played with afflock... does anyone even spec that? :D

![image](https://user-images.githubusercontent.com/45339619/132969774-9c30ba0c-b637-43f6-aebf-43777a7324d0.png)
